### PR TITLE
upgrade webpack form v4 to v5: modify getAssets function, add tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/ssr",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "experimentalDecorators": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+  }
+}

--- a/utils/getAssets.ts
+++ b/utils/getAssets.ts
@@ -18,6 +18,9 @@ interface IStats {
 
 const getAssets = (stats: IStats): Record<string, string[]> => {
     const assets = stats.assets.filter(asset => {
+        // TODO: remove asset.chunks after transition from Webpack 4 to Webpack 5.
+        //  asset.chunks are using with Webpack 4, in Webpack 5 they don't exist.
+        //  asset.chunkNames are using with Webpack 5 instead of assets.chunks
         const chunkHints = asset.chunks || asset.chunkNames;
 
         return chunkHints.includes('index') || chunkHints.includes('common')

--- a/utils/getAssets.ts
+++ b/utils/getAssets.ts
@@ -17,7 +17,11 @@ interface IStats {
 }
 
 const getAssets = (stats: IStats): Record<string, string[]> => {
-    const assets = stats.assets.filter(asset => asset.chunks.includes('index') || asset.chunks.includes('common'));
+    const assets = stats.assets.filter(asset => {
+        const chunkHints = asset.chunks || asset.chunkNames;
+
+        return chunkHints.includes('index') || chunkHints.includes('common')
+    });
 
     return {
         css: assets.filter(asset => /\.css/.test(asset.name)).map(asset => asset.name),


### PR DESCRIPTION
Changes which relate to webpack upgrade from v4 to v5 (stats.assets element now has another object scheme)